### PR TITLE
fix for /communication error

### DIFF
--- a/istio/istioconfig.sh
+++ b/istio/istioconfig.sh
@@ -52,6 +52,7 @@ sed -i 's/\"//g' ./commpts.txt
 sed -i 's/ //g' ./commpts.txt
 sed -i 's/https:\/\///g' ./commpts.txt
 sed -i 's/,//g' ./commpts.txt
+sed -i 's/\/communication//g' ./commpts.txt
 
 while IFS='' read -r line || [[ -n "$line" ]]; do
     echo "  - $line" >> service_entry_oneagent.yml


### PR DESCRIPTION
fixed istio config script to remove /communication from links in oneagent entry file.